### PR TITLE
Chore/issue 45/tailwind globals

### DIFF
--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -1,3 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    body {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 300;
+    }
+}

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -2,7 +2,11 @@
 module.exports = {
   content: ['./src/**/*.{js,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        dmsans: 'DM Sans, sans-serif',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
I've imported the font and its requisite weights for this project (DM Sans). I've added a base style by setting the `font-family` property on the body to the same font. For elements that don't inherit parent CSS, I've extended the font utility class to include `dmsans`, so this class can directly be applied to such elements. 