### PR TITLE
chore(component): update label component to deal with utility classes overrides

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -43,6 +43,7 @@
     "cypress": "^12.8.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
+    "tailwind-merge": "^1.11.0",
     "typescript": "^5.0.2"
   }
 }

--- a/packages/frontend/src/components/ui/Chip/Chip.tsx
+++ b/packages/frontend/src/components/ui/Chip/Chip.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import type { ForwardRefExoticComponent, HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
-import clsx from 'clsx';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { twMerge } from 'tailwind-merge';
 
 export interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
   /**
@@ -24,7 +25,7 @@ ChipProps & React.RefAttributes<HTMLSpanElement>
 > = forwardRef(({
   label, large = false, className, ...rest
 }, ref) => {
-  const spanClassNames = clsx(
+  const spanClassNames = twMerge(
     styles.base,
     large ? 'text-md' : 'text-sm',
     className,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6088,6 +6088,7 @@ __metadata:
     react-dom: 18.2.0
     react-hook-form: ^7.43.7
     string-to-color: ^2.2.2
+    tailwind-merge: ^1.11.0
     tailwindcss: ^3.2.7
     typescript: ^5.0.2
     zod: ^3.21.4
@@ -12000,6 +12001,13 @@ __metadata:
     "@pkgr/utils": ^2.3.1
     tslib: ^2.5.0
   checksum: 8a9560e5d8f3d94dc3cf5f7b9c83490ffa30d320093560a37b88f59483040771fd1750e76b9939abfbb1b5a23fd6dfbae77f6b338abffe7cae7329cd9b9bb86b
+  languageName: node
+  linkType: hard
+
+"tailwind-merge@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "tailwind-merge@npm:1.11.0"
+  checksum: f106dad1c05c51bb0f884bef297d5796820ca905369f0b365c478da7bc773fb85f00f84ff1587ab49eb33ec507d9009b81c49ca19d00e887028dc64548c31296
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I added to `tailwind-merge` package, and substituted the `clsx` function for the `twMerge` function to better handle tailwind utility classes overrides while constructing the className strings.