### PR TITLE
refactor: update/issue 93/make alert visible on scroll

### DIFF
--- a/packages/frontend/src/components/common/AlertPopup/AlertPopup.tsx
+++ b/packages/frontend/src/components/common/AlertPopup/AlertPopup.tsx
@@ -7,7 +7,7 @@ const AlertPopup = () => {
   if (!alert.message) return null;
 
   return (
-    <section>
+    <section className="sticky top-8 left-0 z-50">
       {alert.type && alert.message ? (
         <Alert type={alert.type} message={alert.message} />
       ) : null}

--- a/packages/frontend/src/components/ui/Alert/Alert.tsx
+++ b/packages/frontend/src/components/ui/Alert/Alert.tsx
@@ -12,7 +12,7 @@ const variants: { [key in TAlertType]: string } = {
 };
 
 export const Alert = ({ type, message, icon }: AlertProps) => (
-  <section className="absolute top-8 left-0 w-full flex justify-center animate-slide-in">
+  <section className="w-full flex justify-center animate-slide-in">
     <article
       className={`${variants[type]} flex items-center px-3 py-2 rounded-lg border-2 absolute 3em`}
     >

--- a/packages/frontend/src/layouts/AuthLayout.tsx
+++ b/packages/frontend/src/layouts/AuthLayout.tsx
@@ -83,7 +83,7 @@ const Navigation: React.FC = () => {
 const AuthLayout: React.FC<LayoutProps> = ({ children, seo }) => (
   <>
     <SEO {...seo} />
-    <div className="relative min-h-screen">
+    <div className="h-full min-h-screen">
       <AlertPopup />
       <Navigation />
       {children}


### PR DESCRIPTION
**Problem**
The alert component was not visible on page scroll.

**How Did this PR Solve the Problem**
This PR fixes #93 by defining the sticky position on the AlertPopup component and setting a high z-index on it.
Defining `position: sticky` on an element, auto defines the parent element as the sticky container. This container is the scope of the sticky item.
