### PR TITLE
feat(component): issue 113/create switch toggle component

### DIFF
--- a/packages/frontend/src/components/ui/SwitchToggle/SwitchToggle.tsx
+++ b/packages/frontend/src/components/ui/SwitchToggle/SwitchToggle.tsx
@@ -1,0 +1,34 @@
+import { Switch } from '@headlessui/react';
+import clsx from 'clsx';
+
+export interface SwitchProps {
+  ctrlState: boolean;
+  setCtrlState: () => void;
+  srLabel: string;
+}
+
+export const SwitchToggle = ({
+  ctrlState,
+  setCtrlState,
+  srLabel,
+}: SwitchProps) => (
+  <Switch
+    checked={ctrlState}
+    onChange={setCtrlState}
+    className={clsx('relative inline-flex h-8 w-14 items-center rounded-full', {
+      'bg-gray-800': ctrlState,
+      'bg-gray-200': !ctrlState,
+    })}
+  >
+    <span className="sr-only">{srLabel}</span>
+    <span
+      className={clsx(
+        'inline-block h-6 w-6 transform rounded-full bg-white transition',
+        {
+          'translate-x-7': ctrlState,
+          'translate-x-1': !ctrlState,
+        },
+      )}
+    />
+  </Switch>
+);

--- a/packages/frontend/src/components/ui/SwitchToggle/SwitchToggle.tsx
+++ b/packages/frontend/src/components/ui/SwitchToggle/SwitchToggle.tsx
@@ -2,7 +2,15 @@ import { Switch } from '@headlessui/react';
 import clsx from 'clsx';
 
 export interface SwitchProps {
+  /**
+   * the boolean state the switch is controlling
+   */
   ctrlState: boolean;
+
+  /**
+   *
+   * @returns nth; the function that changes the ctrl state
+   */
   setCtrlState: () => void;
   srLabel: string;
 }

--- a/packages/frontend/src/components/ui/SwitchToggle/index.ts
+++ b/packages/frontend/src/components/ui/SwitchToggle/index.ts
@@ -1,0 +1,1 @@
+export * from './SwitchToggle';

--- a/packages/frontend/src/components/ui/index.ts
+++ b/packages/frontend/src/components/ui/index.ts
@@ -4,3 +4,5 @@ export * from './Input';
 export * from './AlertDialog';
 export * from './Chip';
 export * from './Modal';
+export * from './DropdownMenu';
+export * from './SwitchToggle';


### PR DESCRIPTION
**Description**
This PR resolves #113  by creating the SwitchToggle component using @headlessui. The component simply takes props for the state to be controlled by the switch **(ctrlState)**, the void function that updates that state **(setCtrlState)** & a screen reader label **(srLabel)**, which is not visible text